### PR TITLE
Better handling of Mask/Enable register, allow checking CVRF flag

### DIFF
--- a/src/INA226.cpp
+++ b/src/INA226.cpp
@@ -195,33 +195,33 @@ uint16_t INA226::getMaskEnable(void)
 
 bool INA226::addMaskEnableBit(uint16 mask) 
 {
-  uint16_t temp = getMaskEnable();
-  temp |= mask;
-  return setMaskEnable(temp);
+    uint16_t temp = getMaskEnable();
+    temp |= mask;
+    return setMaskEnable(temp);
 }
 
 bool INA226::enableShuntOverLimitAlert(void) {
-  return addMaskEnableBit(INA226_BIT_SOL);
+    return addMaskEnableBit(INA226_BIT_SOL);
 }
 
 bool INA226::enableShuntUnderLimitAlert(void)
 {
-  return addMaskEnableBit(INA226_BIT_SUL);
+    return addMaskEnableBit(INA226_BIT_SUL);
 }
 
 bool INA226::enableBusOvertLimitAlert(void)
 {
-  return addMaskEnableBit(INA226_BIT_BOL);
+    return addMaskEnableBit(INA226_BIT_BOL);
 }
 
 bool INA226::enableBusUnderLimitAlert(void)
 {
-  return addMaskEnableBit(INA226_BIT_BUL);
+    return addMaskEnableBit(INA226_BIT_BUL);
 }
 
 bool INA226::enableOverPowerLimitAlert(void)
 {
-  return addMaskEnableBit(INA226_BIT_POL);
+    return addMaskEnableBit(INA226_BIT_POL);
 }
 
 bool INA226::enableConversionReadyAlert(void)
@@ -289,24 +289,24 @@ bool INA226::isAlert(void)
 
 bool INA226::isConversionReady(void) 
 {
-  return ((getMaskEnable() & INA226_BIT_CVRF) == INA226_BIT_CVRF);
+    return ((getMaskEnable() & INA226_BIT_CVRF) == INA226_BIT_CVRF);
 }
 
 
 int16_t INA226::readRegister16(uint8_t reg) 
 {
-  int16_t value;
+    int16_t value;
 
-  wire->beginTransmission(inaAddress);
-  wire->write(reg);
-  wire->endTransmission();
+    wire->beginTransmission(inaAddress);
+    wire->write(reg);
+    wire->endTransmission();
 
-  wire->requestFrom(inaAddress, 2);
-  uint8_t vha = wire->read();
-  uint8_t vla = wire->read();
-  value = vha << 8 | vla;
+    wire->requestFrom(inaAddress, 2);
+    uint8_t vha = wire->read();
+    uint8_t vla = wire->read();
+    value = vha << 8 | vla;
 
-  return value;
+    return value;
 }
 
 bool INA226::writeRegister16(uint8_t reg, uint16_t val)

--- a/src/INA226.h
+++ b/src/INA226.h
@@ -146,9 +146,9 @@ private:
 	float currentLSB, powerLSB;
 	float vShuntMax, vBusMax, rShunt;
 
-	bool addMaskEnableBit(uint16 mask);
+    bool addMaskEnableBit(uint16 mask);
     bool setMaskEnable(uint16_t mask);
-	uint16_t getMaskEnable(void);
+    uint16_t getMaskEnable(void);
 
 	bool writeRegister16(uint8_t reg, uint16_t val);
 	int16_t readRegister16(uint8_t reg);

--- a/src/INA226.h
+++ b/src/INA226.h
@@ -110,9 +110,9 @@ class INA226
 	ina226_busConvTime_t getBusConversionTime(void);
 	ina226_shuntConvTime_t getShuntConversionTime(void);
 	ina226_mode_t getMode(void);
-
+    
 	bool enableShuntOverLimitAlert(void);
-	bool enableShuntUnderLimitAlert(void);
+    bool enableShuntUnderLimitAlert(void);
 	bool enableBusOvertLimitAlert(void);
 	bool enableBusUnderLimitAlert(void);
 	bool enableOverPowerLimitAlert(void);
@@ -127,6 +127,7 @@ class INA226
 
 	bool isMathOverflow(void);
 	bool isAlert(void);
+	bool isConversionReady(void);
 
 	float readShuntCurrent(void);
 	float readShuntVoltage(void);
@@ -145,7 +146,8 @@ private:
 	float currentLSB, powerLSB;
 	float vShuntMax, vBusMax, rShunt;
 
-	bool setMaskEnable(uint16_t mask);
+	bool addMaskEnableBit(uint16 mask);
+    bool setMaskEnable(uint16_t mask);
 	uint16_t getMaskEnable(void);
 
 	bool writeRegister16(uint8_t reg, uint16_t val);


### PR DESCRIPTION
Changes: 

- I added some modifications to keep the flags in the Mask/Enable register when setting new ones, instead of setting only the new one.
- Furthemore, I added the function `isConversionReady()` that allows checking the conversion ready flag and with that also resetting the alarm, when only the conversaion alarm is used.
- Removed warning of unused variable in `calibrate()`

Minor change in the include statements to better clarify locality of headers.

Sorry for the changes in formatting, but I couldn't figure out whether tabs or spaces is the way to go.
